### PR TITLE
fix use_cases tests ambiguous mock method

### DIFF
--- a/src/Applications/use_cases/threads/comments/_test/AddCommentToThreadUsecase.test.js
+++ b/src/Applications/use_cases/threads/comments/_test/AddCommentToThreadUsecase.test.js
@@ -1,8 +1,9 @@
 const ThreadsRepository = require('../../../../../Domains/threads/ThreadsRepository')
+const Thread = require('../../../../../Domains/threads/entities/Thread')
 
+const ThreadCommentsRepository = require('../../../../../Domains/threads/comments/ThreadCommentsRepository')
 const AddedComment = require('../../../../../Domains/threads/comments/entities/AddedComment')
 const NewComment = require('../../../../../Domains/threads/comments/entities/NewComment')
-const ThreadCommentsRepository = require('../../../../../Domains/threads/comments/ThreadCommentsRepository')
 
 const AddCommentToThreadUsecase = require('../AddCommentToThreadUsecase')
 
@@ -19,6 +20,13 @@ describe('AddCommentToThreadUsecase', () => {
       content: payload.content,
       owner
     })
+    const mockThread = new Thread({
+      id: 'thread-123',
+      title: 'thread',
+      body: 'thread body',
+      date: new Date(),
+      username: 'dicoding'
+    })
 
     const mockThreadCommentsRepo = new ThreadCommentsRepository()
     const mockThreadsRepo = new ThreadsRepository()
@@ -26,7 +34,7 @@ describe('AddCommentToThreadUsecase', () => {
     mockThreadCommentsRepo.addCommentToThread = jest.fn()
       .mockImplementation(() => Promise.resolve(mockAddedComment))
     mockThreadsRepo.getThreadById = jest.fn()
-      .mockImplementation(() => Promise.resolve())
+      .mockImplementation(() => Promise.resolve(mockThread))
 
     const addCommentToThreadUsecase = new AddCommentToThreadUsecase({
       threadCommentsRepository: mockThreadCommentsRepo,

--- a/src/Applications/use_cases/threads/comments/_test/SoftDeleteCommentUsecase.test.js
+++ b/src/Applications/use_cases/threads/comments/_test/SoftDeleteCommentUsecase.test.js
@@ -1,18 +1,28 @@
-const ThreadCommentsRepository = require('../../../../../Domains/threads/comments/ThreadCommentsRepository')
 const ThreadsRepository = require('../../../../../Domains/threads/ThreadsRepository')
+const Thread = require('../../../../../Domains/threads/entities/Thread')
+
+const ThreadCommentsRepository = require('../../../../../Domains/threads/comments/ThreadCommentsRepository')
 
 const SoftDeleteCommentUsecase = require('../SoftDeleteCommentUsecase')
 
 describe('SoftDeleteCommentUsecase', () => {
   it('should orchestracting the delete comment action correctly', async () => {
     // Arrange
+    const mockThread = new Thread({
+      id: 'thread-123',
+      title: 'thread',
+      body: 'thread body',
+      date: new Date(),
+      username: 'dicoding'
+    })
+
     const mockThreadCommentsRepo = new ThreadCommentsRepository()
     const mockThreadsRepo = new ThreadsRepository()
 
     mockThreadCommentsRepo.softDeleteCommentById = jest.fn()
       .mockImplementation(() => Promise.resolve())
     mockThreadsRepo.getThreadById = jest.fn()
-      .mockImplementation(() => Promise.resolve())
+      .mockImplementation(() => Promise.resolve(mockThread))
 
     const usecase = new SoftDeleteCommentUsecase({
       threadCommentsRepository: mockThreadCommentsRepo,

--- a/src/Applications/use_cases/threads/replies/_test/AddReplyToCommentUsecase.test.js
+++ b/src/Applications/use_cases/threads/replies/_test/AddReplyToCommentUsecase.test.js
@@ -1,5 +1,8 @@
 const ThreadsRepository = require('../../../../../Domains/threads/ThreadsRepository')
+const Thread = require('../../../../../Domains/threads/entities/Thread')
+
 const ThreadCommentsRepository = require('../../../../../Domains/threads/comments/ThreadCommentsRepository')
+
 const ThreadCommentRepliesRepository = require('../../../../../Domains/threads/replies/ThreadCommentRepliesRepository')
 const AddedReply = require('../../../../../Domains/threads/replies/entities/AddedReply')
 const NewReply = require('../../../../../Domains/threads/replies/entities/NewReply')
@@ -19,6 +22,13 @@ describe('AddReplyToCommentUsecase', () => {
       content: payload.content,
       owner
     })
+    const mockThread = new Thread({
+      id: 'thread-123',
+      title: 'thread',
+      body: 'thread body',
+      date: new Date(),
+      username: 'dicoding'
+    })
 
     const mockThreadCommentRepliesRepo = new ThreadCommentRepliesRepository()
     const mockThreadCommentsRepo = new ThreadCommentsRepository()
@@ -29,7 +39,7 @@ describe('AddReplyToCommentUsecase', () => {
     mockThreadCommentsRepo.verifyCommentLocation = jest.fn()
       .mockImplementation(() => Promise.resolve())
     mockThreadsRepo.getThreadById = jest.fn()
-      .mockImplementation(() => Promise.resolve())
+      .mockImplementation(() => Promise.resolve(mockThread))
 
     const addCommentToThreadUsecase = new AddReplyToCommentUsecase({
       threadCommentRepliesRepository: mockThreadCommentRepliesRepo,

--- a/src/Applications/use_cases/threads/replies/_test/SoftDeleteReplyUsecase.test.js
+++ b/src/Applications/use_cases/threads/replies/_test/SoftDeleteReplyUsecase.test.js
@@ -1,4 +1,6 @@
 const ThreadsRepository = require('../../../../../Domains/threads/ThreadsRepository')
+const Thread = require('../../../../../Domains/threads/entities/Thread')
+
 const ThreadCommentsRepository = require('../../../../../Domains/threads/comments/ThreadCommentsRepository')
 const ThreadCommentRepliesRepository = require('../../../../../Domains/threads/replies/ThreadCommentRepliesRepository')
 
@@ -7,6 +9,14 @@ const SoftDeleteReplyUsecase = require('../SoftDeleteReplyUsecase')
 describe('SoftDeleteReplyUsecase', () => {
   it('should orchestracting the delete reply action correctly', async () => {
     // Arrange
+    const mockThread = new Thread({
+      id: 'thread-123',
+      title: 'thread',
+      body: 'thread body',
+      date: new Date(),
+      username: 'dicoding'
+    })
+
     const mockThreadCommentRepliesRepo = new ThreadCommentRepliesRepository()
     const mockThreadCommentsRepo = new ThreadCommentsRepository()
     const mockThreadsRepo = new ThreadsRepository()
@@ -16,7 +26,7 @@ describe('SoftDeleteReplyUsecase', () => {
     mockThreadCommentsRepo.verifyCommentLocation = jest.fn()
       .mockImplementation(() => Promise.resolve())
     mockThreadsRepo.getThreadById = jest.fn()
-      .mockImplementation(() => Promise.resolve())
+      .mockImplementation(() => Promise.resolve(mockThread))
 
     const usecase = new SoftDeleteReplyUsecase({
       threadCommentRepliesRepository: mockThreadCommentRepliesRepo,


### PR DESCRIPTION
re-add mockThread on getThreadById mock on use_cases test to avoid ambiguity.
